### PR TITLE
Add Word8 HTML escaping builders; much faster text escaping

### DIFF
--- a/Blaze/ByteString/Builder/Html/Utf8.hs
+++ b/Blaze/ByteString/Builder/Html/Utf8.hs
@@ -39,7 +39,9 @@ module Blaze.ByteString.Builder.Html.Utf8
 import Data.ByteString.Char8 ()  -- for the 'IsString' instance of bytesrings
 
 import qualified Data.Text      as TS
+import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
 
 import Blaze.ByteString.Builder.Compat.Write ( Write, writePrimBounded )
 import qualified Data.ByteString.Builder       as B
@@ -47,6 +49,7 @@ import           Data.ByteString.Builder.Prim ((>*<), (>$<), condB)
 import qualified Data.ByteString.Builder.Prim  as P
 
 import Blaze.ByteString.Builder.Char.Utf8
+import Blaze.ByteString.Builder.Html.Word
 
 -- | Write a HTML escaped and UTF-8 encoded Unicode character to a bufffer.
 --
@@ -101,9 +104,17 @@ fromHtmlEscapedShow = fromHtmlEscapedString . show
 -- UTF-8 encoding.
 --
 fromHtmlEscapedText :: TS.Text -> B.Builder
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+fromHtmlEscapedText = TE.encodeUtf8BuilderEscaped wordHtmlEscaped
+#else
 fromHtmlEscapedText = fromHtmlEscapedString . TS.unpack
+#endif
 
 -- | /O(n)/. Serialize a HTML escaped Unicode 'TL.Text' using the UTF-8 encoding.
 --
 fromHtmlEscapedLazyText :: TL.Text -> B.Builder
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+fromHtmlEscapedLazyText = TLE.encodeUtf8BuilderEscaped wordHtmlEscaped
+#else
 fromHtmlEscapedLazyText = fromHtmlEscapedString . TL.unpack
+#endif

--- a/Blaze/ByteString/Builder/Html/Word.hs
+++ b/Blaze/ByteString/Builder/Html/Word.hs
@@ -18,20 +18,14 @@
 ------------------------------------------------------------------------------
 
 module Blaze.ByteString.Builder.Html.Word
-  ( 
+  ( wordHtmlEscaped
     -- * Writing HTML escaped bytes to a buffer
-    writeHtmlEscapedWord
+  , writeHtmlEscapedWord
     -- * Creating Builders from HTML escaped bytes
   , fromHtmlEscapedWord
   , fromHtmlEscapedWordList
   , fromHtmlEscapedByteString
   , fromHtmlEscapedLazyByteString
-#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
-    -- * Creating Builders from HTML escaped and UTF-8 encoded text
-    -- | /Note/ that these functions are only available if built against @text >= 1.1.2.0@ and @bytestring >= 0.10.4.0@.
-  , fromHtmlEscapedText
-  , fromHtmlEscapedLazyText
-#endif
   ) where
 
 import qualified Blaze.ByteString.Builder.Compat.Write as W
@@ -41,10 +35,6 @@ import qualified Data.ByteString.Builder.Prim as P
 import           Data.ByteString.Internal (c2w)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Word (Word8)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Encoding as TLE
 
 {-# INLINE wordHtmlEscaped #-}
 wordHtmlEscaped :: P.BoundedPrim Word8
@@ -87,15 +77,3 @@ fromHtmlEscapedByteString = P.primMapByteStringBounded wordHtmlEscaped
 -- | /O(n)/. Serialize a HTML escaped lazy 'BSL.ByteString'.
 fromHtmlEscapedLazyByteString :: BSL.ByteString -> B.Builder
 fromHtmlEscapedLazyByteString = P.primMapLazyByteStringBounded wordHtmlEscaped
-
-#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
--- | /O(n)/. Serialize a HTML escaped strict 'T.Text' using the UTF-8 encoding.
--- This is identical to 'Blaze.ByteString.Builder.Html.Utf8.fromHtmlEscapedText' but more than twice as fast.
-fromHtmlEscapedText :: T.Text -> B.Builder
-fromHtmlEscapedText = TE.encodeUtf8BuilderEscaped wordHtmlEscaped
-
--- | /O(n)/. Serialize a HTML escaped lazy 'TL.Text' using the UTF-8 encoding.
--- This is identical to 'Blaze.ByteString.Builder.Html.Utf8.fromHtmlEscapedLazyText' but more than three times as fast.
-fromHtmlEscapedLazyText :: TL.Text -> B.Builder
-fromHtmlEscapedLazyText = TLE.encodeUtf8BuilderEscaped wordHtmlEscaped
-#endif

--- a/Blaze/ByteString/Builder/Html/Word.hs
+++ b/Blaze/ByteString/Builder/Html/Word.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# OPTIONS_GHC -fsimpl-tick-factor=40000 #-}
+#endif
+
+------------------------------------------------------------------------------
+-- |
+-- Module:      Blaze.ByteString.Builder.Html.Word
+-- Copyright:   (c) 2016 Dylan Simon
+-- License:     BSD3
+-- Maintainer:  Leon P Smith <leon@melding-monads.com>
+-- Stability:   experimental
+--
+-- 'W.Write's and 'B.Builder's for serializing HTML escaped 'Word8' characters
+-- and 'BS.ByteString's that have already been appropriately encoded into HTML by
+-- escaping basic ASCII character references but leaving other bytes untouched.
+--
+------------------------------------------------------------------------------
+
+module Blaze.ByteString.Builder.Html.Word
+  ( 
+    -- * Writing HTML escaped bytes to a buffer
+    writeHtmlEscapedWord
+    -- * Creating Builders from HTML escaped bytes
+  , fromHtmlEscapedWord
+  , fromHtmlEscapedWordList
+  , fromHtmlEscapedByteString
+  , fromHtmlEscapedLazyByteString
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+    -- * Creating Builders from HTML escaped and UTF-8 encoded text
+    -- | /Note/ that these functions are only available if built against @text >= 1.1.2.0@ and @bytestring >= 0.10.4.0@.
+  , fromHtmlEscapedText
+  , fromHtmlEscapedLazyText
+#endif
+  ) where
+
+import qualified Blaze.ByteString.Builder.Compat.Write as W
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Builder.Prim as P
+import           Data.ByteString.Internal (c2w)
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Word (Word8)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+
+{-# INLINE wordHtmlEscaped #-}
+wordHtmlEscaped :: P.BoundedPrim Word8
+wordHtmlEscaped =
+  P.condB (>  c2w '>' ) (P.condB (== c2w '\DEL') P.emptyB $ P.liftFixedToBounded P.word8) $
+  P.condB (== c2w '<' ) (fixed4 ('&',('l',('t',';')))) $        -- &lt;
+  P.condB (== c2w '>' ) (fixed4 ('&',('g',('t',';')))) $        -- &gt;
+  P.condB (== c2w '&' ) (fixed5 ('&',('a',('m',('p',';'))))) $  -- &amp;
+  P.condB (== c2w '"' ) (fixed6 ('&',('q',('u',('o',('t',';')))))) $  -- &quot;
+  P.condB (== c2w '\'') (fixed5 ('&',('#',('3',('9',';'))))) $  -- &#39;
+  P.condB (\c -> c >= c2w ' ' || c == c2w '\t' || c == c2w '\n' || c == c2w '\r')
+        (P.liftFixedToBounded P.word8) P.emptyB
+  where
+  {-# INLINE fixed4 #-}
+  fixed4 x = P.liftFixedToBounded $ const x P.>$<
+    P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8
+  {-# INLINE fixed5 #-}
+  fixed5 x = P.liftFixedToBounded $ const x P.>$<
+    P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8
+  {-# INLINE fixed6 #-}
+  fixed6 x = P.liftFixedToBounded $ const x P.>$<
+    P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8 P.>*< P.char8
+
+-- | Write a HTML escaped byte to a bufffer.
+writeHtmlEscapedWord :: Word8 -> W.Write
+writeHtmlEscapedWord = W.writePrimBounded wordHtmlEscaped
+
+-- | /O(1)./ Serialize a HTML escaped byte.
+fromHtmlEscapedWord :: Word8 -> B.Builder
+fromHtmlEscapedWord = P.primBounded wordHtmlEscaped
+
+-- | /O(n)/. Serialize a HTML escaped list of bytes.
+fromHtmlEscapedWordList :: [Word8] -> B.Builder
+fromHtmlEscapedWordList = P.primMapListBounded wordHtmlEscaped
+
+-- | /O(n)/. Serialize a HTML escaped 'BS.ByteString'.
+fromHtmlEscapedByteString :: BS.ByteString -> B.Builder
+fromHtmlEscapedByteString = P.primMapByteStringBounded wordHtmlEscaped
+
+-- | /O(n)/. Serialize a HTML escaped lazy 'BSL.ByteString'.
+fromHtmlEscapedLazyByteString :: BSL.ByteString -> B.Builder
+fromHtmlEscapedLazyByteString = P.primMapLazyByteStringBounded wordHtmlEscaped
+
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+-- | /O(n)/. Serialize a HTML escaped strict 'T.Text' using the UTF-8 encoding.
+-- This is identical to 'Blaze.ByteString.Builder.Html.Utf8.fromHtmlEscapedText' but more than twice as fast.
+fromHtmlEscapedText :: T.Text -> B.Builder
+fromHtmlEscapedText = TE.encodeUtf8BuilderEscaped wordHtmlEscaped
+
+-- | /O(n)/. Serialize a HTML escaped lazy 'TL.Text' using the UTF-8 encoding.
+-- This is identical to 'Blaze.ByteString.Builder.Html.Utf8.fromHtmlEscapedLazyText' but more than three times as fast.
+fromHtmlEscapedLazyText :: TL.Text -> B.Builder
+fromHtmlEscapedLazyText = TLE.encodeUtf8BuilderEscaped wordHtmlEscaped
+#endif

--- a/benchmarks/StringAndText.hs
+++ b/benchmarks/StringAndText.hs
@@ -27,8 +27,7 @@ import qualified Data.Text.Lazy.Encoding as TL
 import qualified Blaze.ByteString.Builder           as Blaze
 import qualified Data.ByteString.Builder.Internal   as Blaze
 import qualified Blaze.ByteString.Builder.Char.Utf8 as Blaze
-import qualified Blaze.ByteString.Builder.Html.Utf8 as BlazeUtf8
-import qualified Blaze.ByteString.Builder.Html.Word as BlazeWord
+import qualified Blaze.ByteString.Builder.Html.Utf8 as Blaze
 
 main :: IO ()
 main = defaultMain 
@@ -60,19 +59,13 @@ main = defaultMain
         (L.length . TL.encodeUtf8) benchLazyText
 
     , bench "fromHtmlEscapedString :: String --[Html esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedString) benchString
+        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedString) benchString
 
     , bench "fromHtmlEscapedStrictTextUnpacked :: StrictText --[HTML esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedText) benchStrictText
-     
-    , bench "fromHtmlEscapedStrictTextUnpacked :: StrictText --[Utf8 encoding --> HTML esc.]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . BlazeWord.fromHtmlEscapedText) benchStrictText
+        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedText) benchStrictText
      
     , bench "fromHtmlEscapedLazyTextUnpacked :: LazyText --[HTML esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedLazyText) benchLazyText
-     
-    , bench "fromHtmlEscapedLazyTextUnpacked :: LazyText --[Utf8 encoding --> HTML esc.]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . BlazeWord.fromHtmlEscapedLazyText) benchLazyText
+        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedLazyText) benchLazyText
      
     ]
 

--- a/benchmarks/StringAndText.hs
+++ b/benchmarks/StringAndText.hs
@@ -25,8 +25,10 @@ import qualified Data.Text.Lazy          as TL
 import qualified Data.Text.Lazy.Encoding as TL
 
 import qualified Blaze.ByteString.Builder           as Blaze
-import qualified Blaze.ByteString.Builder.Internal  as Blaze
-import qualified Blaze.ByteString.Builder.Html.Utf8 as Blaze
+import qualified Data.ByteString.Builder.Internal   as Blaze
+import qualified Blaze.ByteString.Builder.Char.Utf8 as Blaze
+import qualified Blaze.ByteString.Builder.Html.Utf8 as BlazeUtf8
+import qualified Blaze.ByteString.Builder.Html.Word as BlazeWord
 
 main :: IO ()
 main = defaultMain 
@@ -58,13 +60,19 @@ main = defaultMain
         (L.length . TL.encodeUtf8) benchLazyText
 
     , bench "fromHtmlEscapedString :: String --[Html esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedString) benchString
+        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedString) benchString
 
     , bench "fromHtmlEscapedStrictTextUnpacked :: StrictText --[HTML esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedText) benchStrictText
+        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedText) benchStrictText
+     
+    , bench "fromHtmlEscapedStrictTextUnpacked :: StrictText --[Utf8 encoding --> HTML esc.]--> L.ByteString" $ whnf
+        (L.length . Blaze.toLazyByteString . BlazeWord.fromHtmlEscapedText) benchStrictText
      
     , bench "fromHtmlEscapedLazyTextUnpacked :: LazyText --[HTML esc. & Utf8 encoding]--> L.ByteString" $ whnf
-        (L.length . Blaze.toLazyByteString . Blaze.fromHtmlEscapedLazyText) benchLazyText
+        (L.length . Blaze.toLazyByteString . BlazeUtf8.fromHtmlEscapedLazyText) benchLazyText
+     
+    , bench "fromHtmlEscapedLazyTextUnpacked :: LazyText --[Utf8 encoding --> HTML esc.]--> L.ByteString" $ whnf
+        (L.length . Blaze.toLazyByteString . BlazeWord.fromHtmlEscapedLazyText) benchLazyText
      
     ]
 

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -63,6 +63,7 @@ Library
                      Blaze.ByteString.Builder.Char.Utf8
                      Blaze.ByteString.Builder.Char8
                      Blaze.ByteString.Builder.Html.Utf8
+                     Blaze.ByteString.Builder.Html.Word
                      Blaze.ByteString.Builder.HTTP
                      Blaze.ByteString.Builder.Compat.Write
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -21,6 +21,7 @@ import Codec.Binary.UTF8.String (decode)
 import Blaze.ByteString.Builder
 import Blaze.ByteString.Builder.Char.Utf8
 import Blaze.ByteString.Builder.Html.Utf8
+import qualified Blaze.ByteString.Builder.Html.Word as Word
 
 main :: IO ()
 main = defaultMain $ return $ testGroup "Tests" tests
@@ -39,6 +40,9 @@ tests =
     , testCase     "escaping case 1"           escaping1
     , testCase     "escaping case 2"           escaping2
     , testCase     "escaping case 3"           escaping3
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+    , testProperty "fromHtmlEscapedText"       wordUtf8
+#endif
     ]
 
 monoidLeftIdentity :: Builder -> Bool
@@ -81,6 +85,12 @@ escaping2 = fromString "f &amp;&amp;&amp; g" @?= fromHtmlEscapedString "f &&& g"
 
 escaping3 :: Assertion
 escaping3 = fromString "&quot;&#39;" @?= fromHtmlEscapedString "\"'"
+
+#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
+wordUtf8 :: String -> Property 
+wordUtf8 s = fromHtmlEscapedText t === Word.fromHtmlEscapedText t
+  where t = T.pack s
+#endif
 
 instance Show Builder where
     show = show . toLazyByteString

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -21,7 +21,6 @@ import Codec.Binary.UTF8.String (decode)
 import Blaze.ByteString.Builder
 import Blaze.ByteString.Builder.Char.Utf8
 import Blaze.ByteString.Builder.Html.Utf8
-import qualified Blaze.ByteString.Builder.Html.Word as Word
 
 main :: IO ()
 main = defaultMain $ return $ testGroup "Tests" tests
@@ -40,9 +39,6 @@ tests =
     , testCase     "escaping case 1"           escaping1
     , testCase     "escaping case 2"           escaping2
     , testCase     "escaping case 3"           escaping3
-#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
-    , testProperty "fromHtmlEscapedText"       wordUtf8
-#endif
     ]
 
 monoidLeftIdentity :: Builder -> Bool
@@ -85,12 +81,6 @@ escaping2 = fromString "f &amp;&amp;&amp; g" @?= fromHtmlEscapedString "f &&& g"
 
 escaping3 :: Assertion
 escaping3 = fromString "&quot;&#39;" @?= fromHtmlEscapedString "\"'"
-
-#if MIN_VERSION_text(1,1,2) && MIN_VERSION_bytestring(0,10,4)
-wordUtf8 :: String -> Property 
-wordUtf8 s = fromHtmlEscapedText t === Word.fromHtmlEscapedText t
-  where t = T.pack s
-#endif
 
 instance Show Builder where
     show = show . toLazyByteString


### PR DESCRIPTION
As per #7, Builders for Word8 sequences (ByteStrings) that are already
encoded (in UTF-8) but need HTML escaping.  Also adds versions of
fromHtmlEscapedText based on these.

Add test case that the two fromHtmlEscapedText implementations are
identical, which should provide good coverage.  Also update benchmarks
to compare these two implementations.  Word versions are 3-6x faster.

I tried to match documentation, but style may be a bit different than existing code -- can change this if necessary.  I've also kept both `fromHtmlEscapedText` versions -- another option would be to move the new `Word` version to replace the current `Utf8` version when it's available (text >= 1.1.2, bytestring >= 0.10.4), since it's identical but faster.
