### PR TITLE
Buildable with GHC 8.4

### DIFF
--- a/Blaze/ByteString/Builder/Internal/Write.hs
+++ b/Blaze/ByteString/Builder/Internal/Write.hs
@@ -126,9 +126,6 @@ getBound' msg write =
 instance Semigroup Poke where
   {-# INLINE (<>) #-}
   (Poke po1) <> (Poke po2) = Poke $ po1 >=> po2
-
-  {-# INLINE sconcat #-}
-  sconcat = foldr (<>) mempty
 #endif
 
 instance Monoid Poke where
@@ -148,9 +145,6 @@ instance Semigroup Write where
   {-# INLINE (<>) #-}
   (Write bound1 w1) <> (Write bound2 w2) =
     Write (bound1 + bound2) (w1 <> w2)
-
-  {-# INLINE sconcat #-}
-  sconcat = foldr (<>) mempty
 #endif
 
 instance Monoid Write where

--- a/Blaze/ByteString/Builder/Internal/Write.hs
+++ b/Blaze/ByteString/Builder/Internal/Write.hs
@@ -56,9 +56,9 @@ import Data.ByteString.Builder.Internal
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
-#if !(MIN_VERSION_base(4,11,0))
+
 import Data.Semigroup
-#endif
+
 
 ------------------------------------------------------------------------------
 -- Poking a buffer and writing to a buffer

--- a/Blaze/ByteString/Builder/Internal/Write.hs
+++ b/Blaze/ByteString/Builder/Internal/Write.hs
@@ -138,12 +138,10 @@ instance Monoid Poke where
   mconcat = foldr mappend mempty
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Write where
   {-# INLINE (<>) #-}
   (Write bound1 w1) <> (Write bound2 w2) =
     Write (bound1 + bound2) (w1 <> w2)
-#endif
 
 instance Monoid Write where
   {-# INLINE mempty #-}

--- a/Blaze/ByteString/Builder/Internal/Write.hs
+++ b/Blaze/ByteString/Builder/Internal/Write.hs
@@ -122,11 +122,9 @@ getBound' msg write =
     getBound $ write $ error $
     "getBound' called from " ++ msg ++ ": write bound is not data-independent."
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Poke where
   {-# INLINE (<>) #-}
   (Poke po1) <> (Poke po2) = Poke $ po1 >=> po2
-#endif
 
 instance Monoid Poke where
   {-# INLINE mempty #-}

--- a/Blaze/ByteString/Builder/Internal/Write.hs
+++ b/Blaze/ByteString/Builder/Internal/Write.hs
@@ -141,7 +141,7 @@ instance Monoid Poke where
 instance Semigroup Write where
   {-# INLINE (<>) #-}
   (Write bound1 w1) <> (Write bound2 w2) =
-    Write (bound1 + bound2) (w1 <> w2)
+    Write (bound1 + bound2) (w1 Data.Semigroup.<> w2)
 
 instance Monoid Write where
   {-# INLINE mempty #-}

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -70,7 +70,8 @@ Library
 
   build-depends:     base == 4.* ,
                      deepseq,
-                     text >= 0.10 && < 1.3
+                     text >= 0.10 && < 1.3,
+                     semigroups
 
   if impl(ghc < 7.8)
      build-depends:  bytestring >= 0.9 && < 1.0,


### PR DESCRIPTION
Use default **sconcat** instance which doesn't need **mempty**.