### PR TITLE
Support bytestring-0.11 + allow semigroups-0.19

### DIFF
--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -80,7 +80,7 @@ Library
      build-depends:  bytestring >= 0.10.4 && < 1.0
 
   if impl(ghc < 8.0)
-     build-depends: semigroups >= 0.16 && < 0.19
+     build-depends: semigroups >= 0.16 && < 0.20
 
 test-suite test
   type:           exitcode-stdio-1.0


### PR DESCRIPTION
Tested with the following `cabal.project`:
```
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring
```