### PR TITLE
Fix #23: GHC-9.2 compilation failure due to change in ghc-prim

### DIFF
--- a/Blaze/ByteString/Builder/HTTP.hs
+++ b/Blaze/ByteString/Builder/HTTP.hs
@@ -49,7 +49,11 @@ import Data.Monoid
 shiftr_w32 :: Word32 -> Int -> Word32
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+#if MIN_VERSION_ghc_prim(0,8,0)
+shiftr_w32 (W32# w) (I# i) = W32# (wordToWord32# ((word32ToWord# w) `uncheckedShiftRL#` i))
+#else
 shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`   i)
+#endif
 #else
 shiftr_w32 = shiftR
 #endif

--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -72,6 +72,7 @@ Library
 
   build-depends:     base == 4.* ,
                      deepseq,
+                     ghc-prim,
                      text >= 0.10 && < 1.3
 
   if impl(ghc < 7.8)


### PR DESCRIPTION
Fix #23: GHC-9.2 compilation failure due to change in ghc-prim

The type of `uncheckedShiftRL#` changed in ghc-prim-0.8.0.

The fix is taken from the GHC testsuite, see:

  https://gitlab.haskell.org/ghc/ghc/-/blob/100ffe75f509a73f1b26e768237888646f522b6c/testsuite/tests/profiling/should_run/T3001-2.hs#L159-160

To get the `MIN_VERSION_ghc_prim` macro, `ghc-prim` needs to be added
to the explicit dependencies in the cabal file.